### PR TITLE
Bottom View of Binary Tree

### DIFF
--- a/Bottom View of Binary Tree .cpp
+++ b/Bottom View of Binary Tree .cpp
@@ -1,0 +1,116 @@
+#include <bits/stdc++.h>
+using namespace std;
+#define MAX_HEIGHT 100000
+
+// Tree Node
+struct Node
+{
+    int data;
+    Node* left;
+    Node* right;
+};
+
+Node* newNode(int val)
+{
+    Node* temp = new Node;
+    temp->data = val;
+    temp->left = NULL;
+    temp->right = NULL;
+
+    return temp;
+}
+
+
+vector <int> bottomView(Node *root);
+
+
+Node* buildTree(string str)
+{
+    
+    if(str.length() == 0 || str[0] == 'N')
+        return NULL;
+
+    vector<string> ip;
+
+    istringstream iss(str);
+    for(string str; iss >> str; )
+        ip.push_back(str);
+
+    
+    Node* root = newNode(stoi(ip[0]));
+
+  
+    queue<Node*> queue;
+    queue.push(root);
+
+    int i = 1;
+    while(!queue.empty() && i < ip.size()) {
+
+        Node* currNode = queue.front();
+        queue.pop();
+
+        string currVal = ip[i];
+
+        if(currVal != "N") {
+
+            currNode->left = newNode(stoi(currVal));
+
+            queue.push(currNode->left);
+        }
+
+        i++;
+        if(i >= ip.size())
+            break;
+        currVal = ip[i];
+
+        if(currVal != "N") {
+
+            currNode->right = newNode(stoi(currVal));
+
+            queue.push(currNode->right);
+        }
+        i++;
+    }
+
+    return root;
+}
+
+class Solution {
+  public:
+    vector <int> bottomView(Node *root){
+      vector<int>v;
+        map<int,int>m;
+        queue<pair<Node*,int>>q;
+        q.push({root,0});
+        while(!q.empty())
+        {
+            Node*t=q.front().first;
+            int h=q.front().second;
+            q.pop();
+            m[h]=t->data;
+            if(t->left!=NULL)
+            q.push({t->left,h-1});
+            if(t->right!=NULL)
+            q.push({t->right,h+1});
+            
+        }
+        for(auto x:m)
+        v.push_back(x.second);
+        return v;
+        
+    }
+};
+
+int main() {
+   
+        string s ,ch;
+        getline(cin, s);
+        Node* root = buildTree(s);
+        Solution ob;
+        vector <int> res = ob.bottomView(root);
+        for (int i : res) cout << i << " ";
+        cout << endl;
+    
+    return 0;
+}
+


### PR DESCRIPTION
Given a binary tree, print the bottom view from left to right.
A node is included in bottom view if it can be seen when we look at the tree from bottom.